### PR TITLE
Make initial delay apply immediately and scope tc filters by port

### DIFF
--- a/ping.sh
+++ b/ping.sh
@@ -313,6 +313,7 @@ set_delay_for_key() {
     
     tc filter add dev "$INTERFACE" parent 1: protocol ip prio "$classid" u32 \
         match ip dst "$ip" \
+        match ip dport "$port" 0xffff \
         flowid 1:"$classid" 2>/dev/null
     
     KEY_CLASSID[$key]=$classid
@@ -528,13 +529,18 @@ while true; do
             fi
             
             history_count=$(get_history_count "$key")
-            if [ "$history_count" -lt "$MIN_SAMPLES_BEFORE_ACTION" ]; then
-                debug_log "  $key: накопление замеров ($history_count/$MIN_SAMPLES_BEFORE_ACTION)..."
+            has_rule=${KEY_HAS_RULE[$key]:-0}
+            required_samples=$MIN_SAMPLES_BEFORE_ACTION
+            if [ "$has_rule" -ne 1 ]; then
+                required_samples=1
+            fi
+            if [ "$history_count" -lt "$required_samples" ]; then
+                debug_log "  $key: накопление замеров ($history_count/$required_samples)..."
                 continue
             fi
             
             stable_counter=${KEY_STABLE_COUNTER[$key]:-0}
-            if [ "$stable_counter" -gt 0 ]; then
+            if [ "$has_rule" -eq 1 ] && [ "$stable_counter" -gt 0 ]; then
                 KEY_STABLE_COUNTER[$key]=$((stable_counter - 1))
                 debug_log "  $key: период стабилизации (осталось ${KEY_STABLE_COUNTER[$key]} циклов)"
                 continue


### PR DESCRIPTION
### Motivation
- Ensure new clients receive the configured latency immediately while preserving stabilization behavior for existing rules. 
- Prevent tc filters from matching across services by scoping them to the destination port. 

### Description
- Scope `tc` filter in `set_delay_for_key` by adding `match ip dport "$port" 0xffff` so rules are per-port as well as per-IP. 
- Allow the first delay adjustment to proceed after a single sample by setting `required_samples=1` when `KEY_HAS_RULE` is not set. 
- Skip the stabilization wait for the initial rule by only decrementing/enforcing `KEY_STABLE_COUNTER` when `KEY_HAS_RULE` equals `1`. 
- Preserve existing behavior for later adjustments (hysteresis, min change thresholds, classid lifecycle) for clients that already have a rule. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989a18b4ffc83228ba4f41f467b3816)